### PR TITLE
Fallback Timestamp

### DIFF
--- a/djson/regression_test.go
+++ b/djson/regression_test.go
@@ -1,0 +1,23 @@
+package djson_test
+
+import (
+	"testing"
+
+	"github.com/koenbollen/jl/djson"
+	"github.com/koenbollen/jl/structure"
+)
+
+func TestInvalidTimestampFormat(t *testing.T) {
+	e := structure.Entry{}
+	in := `{"message":"Hi","timestamp":"2017-11-07T15:34:32+0100"}` // invalid timestamp
+	djson.Unmarshal([]byte(in+"\n"), &e)
+	if e.Timestamp != nil && !e.Timestamp.IsZero() {
+		t.Errorf("expected .Timestamp to be nil: %v", e.Timestamp)
+	}
+	if e.RawTimestamp != "2017-11-07T15:34:32+0100" {
+		t.Errorf("expected .RawTimestamp not set: %q", e.RawTimestamp)
+	}
+	if e.Message != "Hi" {
+		t.Errorf("invalid message parsed: %v", e.Message)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -37,7 +37,8 @@ func main() {
 		var err error
 		entry := &structure.Entry{}
 		if line.JSON != nil && len(line.JSON) > 0 {
-			err = json.Unmarshal(line.JSON, entry)
+			var unused interface{}
+			err = json.Unmarshal(line.JSON, &unused)
 			djson.Unmarshal(line.JSON, entry)
 		}
 

--- a/structure/entry.go
+++ b/structure/entry.go
@@ -4,9 +4,10 @@ import "time"
 
 // Entry represents a structured logline to be formatted.
 type Entry struct {
-	Timestamp *time.Time `djson:"timestamp,@timestamp,time,date"`
-	Severity  string     `djson:"severity,level"`
-	Message   string     `djson:"message,msg,text"`
+	Timestamp    *time.Time `djson:"timestamp,@timestamp,time,date"`
+	RawTimestamp string     `djson:"timestamp,@timestamp,time,date"`
+	Severity     string     `djson:"severity,level"`
+	Message      string     `djson:"message,msg,text"`
 
 	Name string `djson:"app,name"`
 }

--- a/structure/format.go
+++ b/structure/format.go
@@ -12,7 +12,7 @@ import (
 )
 
 // DefaultTemplate is used when no template is given.
-const DefaultTemplate = `{{if .Timestamp}}[{{.Timestamp.Format "2006-01-02 15:04:05"}}] {{end}}{{if .Severity}}{{.Severity}}: {{end}}{{.Message}}`
+const DefaultTemplate = `{{if .Timestamp}}[{{.Timestamp.Format "2006-01-02 15:04:05"}}] {{else if .RawTimestamp}}[{{.RawTimestamp}}] {{end}}{{if .Severity}}{{.Severity}}: {{end}}{{.Message}}`
 
 var severityMapping = map[string]string{
 	"10":   "TRACE",
@@ -95,6 +95,10 @@ func (f *Formatter) Format(entry *Entry, raw json.RawMessage, prefix, suffix []b
 }
 
 func (f *Formatter) enhance(entry *Entry) {
+	if entry.Timestamp != nil && entry.Timestamp.IsZero() {
+		entry.Timestamp = nil
+	}
+
 	entry.Severity = strings.ToUpper(entry.Severity)
 	if level, ok := severityMapping[entry.Severity]; ok {
 		entry.Severity = level


### PR DESCRIPTION
In some cases the timestamp fields contains an incompatible timestamp format for Go. This change will then fallback to a string only timestamp.