### PR TITLE
Copy byte slices in result struct of the logstream

### DIFF
--- a/stream/logs.go
+++ b/stream/logs.go
@@ -51,10 +51,14 @@ func (l *stream) run() {
 		json := l.parse(raw)
 		prefix, suffix := split(raw, json)
 		line := &Line{
-			Raw:    raw,
-			JSON:   json,
+			Raw:    make([]byte, len(raw)),
 			Prefix: prefix,
 			Suffix: suffix,
+		}
+		copy(line.Raw, raw)
+		if json != nil {
+			line.JSON = make([]byte, len(json))
+			copy(line.JSON, json)
 		}
 		select {
 		case <-l.stop:


### PR DESCRIPTION
This to prevent a data-race which is sometimes crashing the process
entirely.

Closes #9