### PR TITLE
Support zap timestamps

### DIFF
--- a/djson/regression_test.go
+++ b/djson/regression_test.go
@@ -21,3 +21,23 @@ func TestInvalidTimestampFormat(t *testing.T) {
 		t.Errorf("invalid message parsed: %v", e.Message)
 	}
 }
+
+func TestFloatTimestamp(t *testing.T) {
+	in := `{"level":"info","ts":1565361391.4279764,"caller":"ingress/main.go:109","msg":"Hi","environment":"production","artifact":"workflow","component":"ingress"}`
+	e := structure.Entry{}
+	djson.Unmarshal([]byte(in+"\n"), &e)
+	if e.Timestamp != nil && !e.Timestamp.IsZero() {
+		t.Errorf("expected .Timestamp to be nil: %v", e.Timestamp)
+	}
+	expectedRawTimestamp := "1.5653613914279764e+09"
+	if e.RawTimestamp != expectedRawTimestamp {
+		t.Errorf("expected .RawTimestamp to be %q, got %q", expectedRawTimestamp, e.RawTimestamp)
+	}
+	expectedFloatTimestamp := 1565361391.4279764
+	if e.FloatTimestamp != expectedFloatTimestamp {
+		t.Errorf("expected .RawTimestamp to be %v, got %v", expectedFloatTimestamp, e.FloatTimestamp)
+	}
+	if e.Message != "Hi" {
+		t.Errorf("invalid message parsed: %v", e.Message)
+	}
+}

--- a/examples/mocks/some_zap_program
+++ b/examples/mocks/some_zap_program
@@ -9,4 +9,4 @@ if [ "$1" = "--complex-error" ]; then
   printf '{"severity":"ERROR","timestamp":"2017-11-22T15:32:28.907Z","caller":"kafka/consumer.go:63","message":"Kafka consumer received error.","app":"stream-processor-ses-mailer","tier":"mailer","production":false,"version":"5bb5b52","environment":"development","error":"kafka server: The provided member is not known in the current generation.","stacktrace":"github.com/koenbollen/stream-processor-example/vendor/github.com/blendle/go-streamprocessor/streamclient/kafka.(*Client).NewConsumer.func2\\n\\t/home/jenkins/go/src/github.com/koenbollen/stream-processor-example/vendor/github.com/blendle/go-streamprocessor/streamclient/kafka/consumer.go:63"}'
   exit
 fi
-echo '{"level":"info","message":"logger construction succeeded","foo":"bar"}'
+echo '{"level":"info","message":"logger construction succeeded","foo":"bar","ts":1565361391.4279764}'

--- a/examples/zap.md
+++ b/examples/zap.md
@@ -1,9 +1,9 @@
 
     $ some_zap_program
-    {"level":"info","message":"logger construction succeeded","foo":"bar"}
+    {"level":"info","message":"logger construction succeeded","foo":"bar","ts":1565361391.4279764}
 
     $ some_zap_program | jl
-       INFO: logger construction succeeded [foo=bar]
+    [2019-08-09 14:36:31]    INFO: logger construction succeeded [foo=bar]
 
     $ some_zap_program --error
     {"level":"error","msg":"panic!","error":"timeout","stack":"go.uber.org/zap.Stack\n\tgo.uber.org/zap/field.go:191\nmain.somefunction\n\tmain.go:11\nmain.main\n\tmain.go:15"} (no-eol)

--- a/main.go
+++ b/main.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"os"
+	"time"
 
 	"github.com/koenbollen/jl/djson"
 	"github.com/koenbollen/jl/stream"
@@ -48,6 +50,12 @@ func main() {
 			writeBytes(line.Raw)
 			writeBytes(structure.NewLine)
 			continue
+		}
+
+		if (entry.Timestamp == nil || entry.Timestamp.IsZero()) && entry.FloatTimestamp > 0 {
+			sec, dec := math.Modf(entry.FloatTimestamp)
+			t := time.Unix(int64(sec), int64(dec*(1e9)))
+			entry.Timestamp = &t
 		}
 
 		// Passing entry to formatter to output:

--- a/structure/entry.go
+++ b/structure/entry.go
@@ -4,10 +4,11 @@ import "time"
 
 // Entry represents a structured logline to be formatted.
 type Entry struct {
-	Timestamp    *time.Time `djson:"timestamp,@timestamp,time,date"`
-	RawTimestamp string     `djson:"timestamp,@timestamp,time,date"`
-	Severity     string     `djson:"severity,level"`
-	Message      string     `djson:"message,msg,text"`
+	Timestamp      *time.Time `djson:"timestamp,@timestamp,time,date,ts"`
+	RawTimestamp   string     `djson:"timestamp,@timestamp,time,date,ts"`
+	FloatTimestamp float64    `djson:"timestamp,@timestamp,time,date,ts"`
+	Severity       string     `djson:"severity,level"`
+	Message        string     `djson:"message,msg,text"`
 
 	Name string `djson:"app,name"`
 }

--- a/structure/format.go
+++ b/structure/format.go
@@ -25,7 +25,7 @@ var severityMapping = map[string]string{
 }
 
 var fieldsToSkip = []string{
-	"@timestamp", "hostname", "level", "message", "msg", "name", "pid", "severity", "text", "time", "timestamp", "v",
+	"@timestamp", "hostname", "level", "message", "msg", "name", "pid", "severity", "text", "time", "timestamp", "ts", "v",
 }
 
 // NewLine contains ['\n']


### PR DESCRIPTION
[zap](https://github.com/uber-go/zap) uses the timestamp field `ts` with a unix timestamp formatted in a float (eg: `"ts":1565361391.4279764`).
This was not supported by jl and this PR corrects that.