### PR TITLE
Disable scientific notation for numbers

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -34,7 +34,7 @@ Formatting Options:
   --skip-fields     Don't output misc json keys as fields
   --include-fields <fields>, -f <fields>
                     Always include these json keys as fields (comma
-                    seperated list)
+                    separated list)
 
 You can add any option to the JL_OPTS environment variable, ex:
   export JL_OPTS="--no-color"

--- a/structure/format.go
+++ b/structure/format.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -151,7 +152,12 @@ func (f *Formatter) outputFields(entry *Entry, raw json.RawMessage) {
 				continue
 			}
 			if !f.shouldSkipField(key, value) {
-				output = append(output, fmt.Sprintf("%s=%v", key, value))
+				switch v := value.(type) {
+				case float64:
+					output = append(output, key+"="+strconv.FormatFloat(v, 'f', -1, 64))
+				default:
+					output = append(output, fmt.Sprintf("%s=%v", key, value))
+				}
 			}
 		}
 		if len(output) > 0 {

--- a/structure/format_test.go
+++ b/structure/format_test.go
@@ -14,7 +14,9 @@ const example = `{
   "severity": "30",
   "timestamp": "2015-02-11T13:37:00Z",
   "lang": "fr",
-  "labels": {"git_rev": "0992944"}
+  "labels": {"git_rev": "0992944"},
+  "long_number": 22501438,
+  "float_number": 2250.1438
 }`
 
 func TestHappypath(t *testing.T) {
@@ -33,8 +35,9 @@ func TestHappypath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to format entry: %v", err)
 	}
-	if buf.String() != "[2015-02-11 13:37:00]    INFO: Hello, world [git_rev=0992944 lang=fr]\n" {
-		t.Errorf("invalid output: %q", buf.String())
+	expect1 := "[2015-02-11 13:37:00]    INFO: Hello, world [float_number=2250.1438 git_rev=0992944 lang=fr long_number=22501438]\n"
+	if buf.String() != expect1 {
+		t.Errorf("\n\tnot match: %q\n\t   expect: %q\n", buf.String(), expect1)
 	}
 
 	buf.Reset()
@@ -42,7 +45,8 @@ func TestHappypath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to format entry: %v", err)
 	}
-	if buf.String() != "prefix: [2015-02-11 13:37:00]    INFO: Hello, world [git_rev=0992944 lang=fr] suffix!\n" {
-		t.Errorf("invalid output: %q", buf.String())
+	expect2 := "prefix: [2015-02-11 13:37:00]    INFO: Hello, world [float_number=2250.1438 git_rev=0992944 lang=fr long_number=22501438] suffix!\n"
+	if buf.String() != expect2 {
+		t.Errorf("\n\tnot match: %q\n\t   expect: %q\n", buf.String(), expect2)
 	}
 }


### PR DESCRIPTION
As all numbers in JSON are floats and there is no modifiers in Go's fmt package which could print floats without fractional part if it's zero and suppress scientific notation output at the same time (primer: https://play.golang.org/p/EDftOgpLalf), so it makes bad logs grep experience. User expects while grepping some field `22501438` value, but in `jl` output this number looks like `2.2501438e+07`, so nothing matches.

This PR fixes it.