### PR TITLE
Milliseconds support

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -30,14 +30,13 @@ Output Options:
   --no-color        Don't colorize output
   --skip-prefix     Skip printing truncated bytes before the JSON
   --skip-suffix     Skip printing truncated bytes after the JSON
-  
-  --timestamp		format of timestamps, supported are seconds(default) and milliseconds
 
 Formatting Options:
   --skip-fields     Don't output misc json keys as fields
   --include-fields <fields>, -f <fields>
                     Always include these json keys as fields (comma
-                    separated list)
+					separated list)
+  --timestamp		<timestamp format> set up the format of timestamps, supported are seconds(default) and milliseconds
 
 You can add any option to the JL_OPTS environment variable, ex:
   export JL_OPTS="--no-color"

--- a/cli.go
+++ b/cli.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"strings"
+	"time"
 
 	"github.com/docopt/docopt-go"
 	"github.com/mattn/go-isatty"
@@ -29,6 +30,8 @@ Output Options:
   --no-color        Don't colorize output
   --skip-prefix     Skip printing truncated bytes before the JSON
   --skip-suffix     Skip printing truncated bytes after the JSON
+  
+  --timestamp		format of timestamps, supported are seconds(default) and milliseconds
 
 Formatting Options:
   --skip-fields     Don't output misc json keys as fields
@@ -46,7 +49,7 @@ Example:
 
 var version = "v1.2.0"
 
-func cli() (files []string, color, showPrefix, showSuffix, showFields bool, includeFields string) {
+func cli() (files []string, color, showPrefix, showSuffix, showFields bool, includeFields string, timestampFormat time.Duration) {
 	argv := append(os.Args[1:], strings.Split(os.Getenv("JL_OPTS"), " ")...)
 	arguments, err := docopt.Parse(usage, argv, true, "jl "+version, false)
 	if err != nil {
@@ -58,6 +61,20 @@ func cli() (files []string, color, showPrefix, showSuffix, showFields bool, incl
 	showSuffix = !arguments["--skip-suffix"].(bool)
 	showFields = !arguments["--skip-fields"].(bool)
 	includeFields, _ = arguments["--include-fields"].(string)
+
+	timestampFormatAsString, _ := arguments["--timestamp"].(string)
+	timestampFormat = determineTimestampsFormat(timestampFormatAsString)
+
 	files = arguments["FILE"].([]string)
 	return
+}
+
+func determineTimestampsFormat(timestampFormat string) (timestampDurationFormat time.Duration) {
+	switch timestampFormat {
+	case "milliseconds":
+		return time.Millisecond
+	default:
+		return time.Second
+	}
+
 }

--- a/gobuild.sh
+++ b/gobuild.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -eux
+
+export GOPATH="$(pwd)/.gobuild"
+SRCDIR="${GOPATH}/src/github.com/dmytrokosiachenko/jl"
+
+[ -d ${GOPATH} ] && rm -rf ${GOPATH}
+mkdir -p ${GOPATH}/{src,pkg,bin}
+mkdir -p ${SRCDIR}
+cp tf.go ${SRCDIR}
+(
+    echo ${GOPATH}
+    cd ${SRCDIR}
+    go get .
+    go install .
+)

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 func main() {
-	files, color, showPrefix, showSuffix, showFields, includeFields := cli()
+	files, color, showPrefix, showSuffix, showFields, includeFields, timestampFormat := cli()
 	formatter, err := structure.NewFormatter(os.Stdout, "")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "invalid format: %v\n", err)
@@ -54,6 +54,9 @@ func main() {
 
 		if (entry.Timestamp == nil || entry.Timestamp.IsZero()) && entry.FloatTimestamp > 0 {
 			sec, dec := math.Modf(entry.FloatTimestamp)
+			if timestampFormat == time.Millisecond {
+				sec = sec / 1000
+			}
 			t := time.Unix(int64(sec), int64(dec*(1e9))).UTC()
 			entry.Timestamp = &t
 		}


### PR DESCRIPTION
Added support for milliseconds in the timestamps.
For example there is json log with milliseconds as timestamp like this:
`{"time":1597246404774,"sourceApplication":"service-v1","severity":"INFO","severity_value":20000,"message":"Initializing Servlet 'dispatcherServlet'"}`

Old implementation interprets it like:
`[52584-09-21 04:52:54]    INFO: Initializing Servlet dispatcherServlet [severity_value=20000 sourceApplication=service-v1]`

and the new one like this:
`[2020-08-12 15:33:24]    INFO: Initializing Servlet dispatcherServlet [severity_value=20000 sourceApplication=service-v1]`