### PR TITLE
Auto-detect if timestamps are in milliseconds.

### DIFF
--- a/examples/milliseconds.md
+++ b/examples/milliseconds.md
@@ -1,0 +1,10 @@
+# Timestamp milliseconds detection
+
+`jl` automatically guesses if your timestamps are in milliseconds or seconds
+when a unix timestamp is used:
+
+    $ echo '{"time":1597246404774, "app":"service-v1","severity":"INFO","message":"Initializing Servlet dispatcher"}' | jl
+    [2020-08-12 15:33:24]    INFO: Initializing Servlet dispatcher [app=service-v1]
+
+    $ echo '{"time":1597246404,    "app":"service-v1","severity":"INFO","message":"Initializing Servlet dispatcher"}' | jl
+    [2020-08-12 15:33:24]    INFO: Initializing Servlet dispatcher [app=service-v1]

--- a/structure/format.go
+++ b/structure/format.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/fatih/color"
 )
@@ -100,6 +101,12 @@ func (f *Formatter) Format(entry *Entry, raw json.RawMessage, prefix, suffix []b
 func (f *Formatter) enhance(entry *Entry) {
 	if entry.Timestamp != nil && entry.Timestamp.IsZero() {
 		entry.Timestamp = nil
+	}
+
+	if entry.Timestamp != nil && entry.Timestamp.Year() > 3000 { // timestamp was probably in milliseconds
+		t := *entry.Timestamp
+		t = time.Unix(t.Unix()/int64(time.Second/time.Millisecond), 0).UTC()
+		entry.Timestamp = &t
 	}
 
 	entry.Severity = strings.ToUpper(entry.Severity)


### PR DESCRIPTION
This change adds the detection of timestamps in milliseconds. 
Includes a new test example.