### PR TITLE
Add support for messages in a nested object.

### DIFF
--- a/djson/unmarshal.go
+++ b/djson/unmarshal.go
@@ -29,7 +29,9 @@ func process(data []byte, val interface{}, elem reflect.Type, i int) {
 	if !ok {
 		return
 	}
-	for _, key := range strings.Split(keys, ",") {
+	keylist := strings.Split(keys, ",")
+	reverse(keylist) // to prioritize the keys in the beginning of the list
+	for _, key := range keylist {
 		result := gjson.GetBytes(data, strings.TrimSpace(key))
 		if !result.Exists() {
 			result = gjson.GetBytes(data, strings.ReplaceAll(strings.TrimSpace(key), ".", "\\."))
@@ -66,4 +68,10 @@ func convert(value, field reflect.Value) reflect.Value {
 		}
 	}
 	return reflect.ValueOf(nil)
+}
+
+func reverse[S ~[]T, T any](s S) {
+	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
+		s[i], s[j] = s[j], s[i]
+	}
 }

--- a/djson/unmarshal_test.go
+++ b/djson/unmarshal_test.go
@@ -140,3 +140,25 @@ func TestDoubleNestedType(t *testing.T) {
 		t.Error("failed to set .Level from nested path")
 	}
 }
+
+func TestWildcardNested(t *testing.T) {
+	t.Parallel()
+	val := struct {
+		Message string `djson:"message,*.message"`
+	}{}
+
+	djson.Unmarshal([]byte(`{"fields.message": "Hello"}`), &val)
+	if val.Message != "Hello" {
+		t.Error("failed to set .Message from static flat path")
+	}
+
+	djson.Unmarshal([]byte(`{"fields": {"message": "Hello"}}`), &val)
+	if val.Message != "Hello" {
+		t.Error("failed to set .Message from nested path")
+	}
+
+	djson.Unmarshal([]byte(`{"message": "First", "fields.message": "Second"}`), &val)
+	if val.Message != "First" {
+		t.Error("failed to set .Message from first key")
+	}
+}

--- a/examples/mocks/myprogram
+++ b/examples/mocks/myprogram
@@ -12,6 +12,9 @@ elif [ "$1" = "--complex" ]; then
 elif [ "$1" = "--no-message" ]; then
   echo '{"message": "", "severity": "trace", "timestamp": "2017-09-28T06:43:13Z", "user": "john"}'
   echo '{"msg": "", "severity": "error", "timestamp": "2017-09-28T06:43:14Z", "@version": "1.0.0"}'
+elif [ "$1" = "--nested-message" ]; then
+  echo '{"timestamp":"2022-02-15T18:47:10.821422Z","level":"INFO","fields":{"message":"shaving yaks","yaks":7},"target":"fmt_json","spans":{"yaks":7,"name":"shaving_yaks"}}'
+  echo '{"timestamp":"2022-02-15T18:47:10.821495Z","level":"TRACE","fields":{"message":"hello! Im gonna shave a yak","excitement":"yay!"},"target":"fmt_json","spans":{"yaks":7,"name":"shaving_yaks"}}'
 else
   echo '{"message": "Hello, world!!", "severity": "info"}'
   echo '{"message": "skipping file", "severity": "warn", "file": "empty.txt"}'

--- a/examples/nested_fields.md
+++ b/examples/nested_fields.md
@@ -1,0 +1,33 @@
+# Nested Fields
+
+By default `jl` will ignore nested fields unless you explicitly include them:
+
+    $ echo '{"msg":"Booting...", "level": "INFO", "meta": {"app": "backend", "server": 6}}' | jl
+       INFO: Booting...
+
+    $ echo '{"msg":"Booting...", "level": "INFO", "meta": {"app": "backend", "server": 6}}' | jl -f meta.app
+       INFO: Booting... [meta.app=backend]
+
+    $ echo '{"msg":"Booting...", "level": "INFO", "meta": {"app": "backend", "server": 6}}' | jl -f meta
+       INFO: Booting... [meta.app=backend meta.server=6]
+
+
+Some logging formats have their message in a nested fields, like
+[tokio/tracing](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/struct.Json.html#example-output)
+for example, have the log message in the `.fields.message` field:
+
+    $ myprogram --nested-message
+    {"timestamp":"2022-02-15T18:47:10.821422Z","level":"INFO","fields":{"message":"shaving yaks","yaks":7},"target":"fmt_json","spans":{"yaks":7,"name":"shaving_yaks"}}
+    {"timestamp":"2022-02-15T18:47:10.821495Z","level":"TRACE","fields":{"message":"hello! Im gonna shave a yak","excitement":"yay!"},"target":"fmt_json","spans":{"yaks":7,"name":"shaving_yaks"}}
+
+`jl` will also look for the json path `.*.message`, and when it finds `.fields.message` it will output that message and automatically include the `fields` object:
+
+    $ myprogram --nested-message | jl
+    [2022-02-15 18:47:10]    INFO: shaving yaks [fields.yaks=7 target=fmt_json]
+    [2022-02-15 18:47:10]   TRACE: hello! Im gonna shave a yak [fields.excitement=yay! target=fmt_json]
+
+You can also explicitly include other nested objects as well:
+
+    $ myprogram --nested-message | jl -f spans
+    [2022-02-15 18:47:10]    INFO: shaving yaks [fields.yaks=7 spans.name=shaving_yaks spans.yaks=7 target=fmt_json]
+    [2022-02-15 18:47:10]   TRACE: hello! Im gonna shave a yak [fields.excitement=yay! spans.name=shaving_yaks spans.yaks=7 target=fmt_json]

--- a/main.go
+++ b/main.go
@@ -66,8 +66,7 @@ func main() {
 
 		for _, processor := range processors.All {
 			if processor.Detect(line, entry) {
-				err = processor.Process(line, entry)
-				if err != nil {
+				if err := processor.Process(line, entry); err != nil {
 					fmt.Fprintf(os.Stderr, "failed to process message: %v\n", err)
 					os.Exit(1)
 				}

--- a/main.go
+++ b/main.go
@@ -42,9 +42,7 @@ func main() {
 	s := stream.New(r)
 	for line := range s.Lines() {
 		var err error
-		entry := &structure.Entry{
-			SkipFields: make(map[string]bool),
-		}
+		entry := &structure.Entry{}
 		if line.JSON != nil && len(line.JSON) > 0 {
 			var unused interface{}
 			err = json.Unmarshal(line.JSON, &unused)

--- a/main.go
+++ b/main.go
@@ -66,7 +66,8 @@ func main() {
 
 		for _, processor := range processors.All {
 			if processor.Detect(line, entry) {
-				if err := processor.Process(line, entry); err != nil {
+				err = processor.Process(line, entry)
+				if err != nil {
 					fmt.Fprintf(os.Stderr, "failed to process message: %v\n", err)
 					os.Exit(1)
 				}

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func main() {
 	formatter.ShowSuffix = showSuffix
 	formatter.ShowFields = showFields
 	formatter.MaxFieldLength = maxFieldLength
-	formatter.IncludeFields = includeFields
+	formatter.IncludeFields = strings.Split(includeFields, ",")
 	formatter.ExcludeFields = append(formatter.ExcludeFields, strings.Split(excludeFields, ",")...)
 
 	r, err := openFiles(files)

--- a/processors/nested.go
+++ b/processors/nested.go
@@ -1,0 +1,27 @@
+package processors
+
+import (
+	"strings"
+
+	"github.com/koenbollen/jl/stream"
+	"github.com/koenbollen/jl/structure"
+	"github.com/tidwall/gjson"
+)
+
+type NestedProcessor struct {
+}
+
+func (p *NestedProcessor) Detect(line *stream.Line, entry *structure.Entry) bool {
+	result := gjson.GetBytes(line.JSON, "*.message")
+	return result.Exists() && result.String() != "" && entry.Message == result.String()
+}
+
+func (p *NestedProcessor) Process(line *stream.Line, entry *structure.Entry) error {
+	result := gjson.GetBytes(line.JSON, "*.message")
+	path := result.Path(string(line.JSON))
+	if field, _, found := strings.Cut(path, ".message"); found {
+		entry.IncludeFields = append(entry.IncludeFields, field)
+		entry.ExcludeFields = append(entry.ExcludeFields, path)
+	}
+	return nil
+}

--- a/processors/nested_test.go
+++ b/processors/nested_test.go
@@ -1,0 +1,48 @@
+package processors
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/koenbollen/jl/djson"
+	"github.com/koenbollen/jl/stream"
+	"github.com/koenbollen/jl/structure"
+)
+
+func TestNested(t *testing.T) {
+
+	in := `{
+		"level": "INFO",
+		"nested": {
+			"message": "Hi",
+			"user": 56
+		}
+	}`
+
+	raw := &bytes.Buffer{}
+	_ = json.Compact(raw, []byte(in))
+
+	line := &stream.Line{Raw: raw.Bytes(), JSON: raw.Bytes()}
+	entry := &structure.Entry{Message: "Hi"}
+	djson.Unmarshal(line.JSON, entry)
+
+	p := &NestedProcessor{}
+
+	detected := p.Detect(line, entry)
+	if got, want := detected, true; got != want {
+		t.Errorf("Detect() = %v, want %v", got, want)
+	}
+
+	err := p.Process(line, entry)
+	if err != nil {
+		t.Errorf("Process() = %v, want nil", err)
+	}
+
+	if got, want := entry.Message, "Hi"; got != want {
+		t.Errorf("entry.Message = %v, want %v", got, want)
+	}
+	if got, want := entry.IncludeFields[0], "nested"; got != want {
+		t.Errorf("entry.IncludeFields = %v, want %v", got, want)
+	}
+}

--- a/processors/shared.go
+++ b/processors/shared.go
@@ -11,5 +11,6 @@ type Processor interface {
 }
 
 var All = []Processor{
+	&NestedProcessor{},
 	&JournaldProcessor{},
 }

--- a/structure/colors.go
+++ b/structure/colors.go
@@ -4,7 +4,7 @@ import "github.com/fatih/color"
 
 var messageColor = color.New(color.FgHiCyan, color.Bold).SprintFunc()
 var severityColors = map[string]func(a ...interface{}) string{
-	"TRACE":   color.New(color.FgBlack).SprintFunc(),
+	"TRACE":   color.New(color.FgHiBlack).SprintFunc(),
 	"DEBUG":   color.New(color.FgHiBlack).SprintFunc(),
 	"INFO":    color.New(color.FgCyan).SprintFunc(),
 	"WARNING": color.New(color.FgRed).SprintFunc(),

--- a/structure/entry.go
+++ b/structure/entry.go
@@ -8,7 +8,7 @@ type Entry struct {
 	RawTimestamp   string     `djson:"timestamp,@timestamp,time,date,ts"`
 	FloatTimestamp float64    `djson:"timestamp,@timestamp,time,date,ts"`
 	Severity       string     `djson:"severity,level,log.level"`
-	Message        string     `djson:"message,msg,text,MESSAGE"`
+	Message        string     `djson:"message,msg,text"`
 
 	Name string `djson:"app,name,service.name"`
 

--- a/structure/entry.go
+++ b/structure/entry.go
@@ -8,10 +8,13 @@ type Entry struct {
 	RawTimestamp   string     `djson:"timestamp,@timestamp,time,date,ts"`
 	FloatTimestamp float64    `djson:"timestamp,@timestamp,time,date,ts"`
 	Severity       string     `djson:"severity,level,log.level"`
-	Message        string     `djson:"message,msg,text"`
+	Message        string     `djson:"message,msg,text,*.message"`
 
 	Name string `djson:"app,name,service.name"`
 
-	// SkipFields is used by processors to indicate which fields should be skipped
-	SkipFields map[string]bool
+	// IncludeFields is used by processors to indicate which fields should be included
+	IncludeFields []string
+
+	// ExcludeFields is used by processors to indicate which fields should be skipped
+	ExcludeFields []string
 }

--- a/structure/entry.go
+++ b/structure/entry.go
@@ -8,7 +8,7 @@ type Entry struct {
 	RawTimestamp   string     `djson:"timestamp,@timestamp,time,date,ts"`
 	FloatTimestamp float64    `djson:"timestamp,@timestamp,time,date,ts"`
 	Severity       string     `djson:"severity,level,log.level"`
-	Message        string     `djson:"message,msg,text"`
+	Message        string     `djson:"message,msg,text,MESSAGE"`
 
 	Name string `djson:"app,name,service.name"`
 

--- a/structure/format.go
+++ b/structure/format.go
@@ -184,13 +184,23 @@ func (f *Formatter) shouldSkipField(entry *Entry, field, path string, value inte
 	if strings.Contains(f.IncludeFields, field) || strings.Contains(f.IncludeFields, path) {
 		return false
 	}
-	if strings.Count(path, ".") > 1 { // Only include nested fields when the are in the IncludeFields
+	if contains(entry.IncludeFields, field) {
+		return true
+	}
+	if contains(entry.ExcludeFields, field) {
+		return true
+	}
+	if strings.Count(path, ".") > 1 {
+		first, _, _ := strings.Cut(strings.Trim(path, "."), ".")
+		if strings.Contains(f.IncludeFields, first) {
+			return false
+		}
+		if contains(entry.IncludeFields, first) {
+			return false
+		}
 		return true
 	}
 	if f.MaxFieldLength > 0 && len(path+fmt.Sprintf("%v", value)) >= f.MaxFieldLength {
-		return true
-	}
-	if _, skip := entry.SkipFields[field]; skip {
 		return true
 	}
 	return contains(f.ExcludeFields, field)

--- a/structure/format.go
+++ b/structure/format.go
@@ -44,7 +44,7 @@ type Formatter struct {
 	MaxFieldLength int
 	ShowPrefix     bool
 	ShowSuffix     bool
-	IncludeFields  string
+	IncludeFields  []string
 	ExcludeFields  []string
 }
 
@@ -66,7 +66,6 @@ func NewFormatter(w io.Writer, fmt string) (*Formatter, error) {
 		MaxFieldLength: 30,
 		ShowPrefix:     true,
 		ShowSuffix:     true,
-		IncludeFields:  "",
 		ExcludeFields:  defaultExcludes,
 	}, nil
 }
@@ -181,18 +180,18 @@ func (f *Formatter) outputFields(entry *Entry, raw json.RawMessage) {
 }
 
 func (f *Formatter) shouldSkipField(entry *Entry, field, path string, value interface{}) bool {
-	if strings.Contains(f.IncludeFields, field) || strings.Contains(f.IncludeFields, path) {
+	if contains(f.IncludeFields, field) || contains(f.IncludeFields, path) {
 		return false
 	}
 	if contains(entry.IncludeFields, field) {
-		return true
+		return false
 	}
 	if contains(entry.ExcludeFields, field) {
 		return true
 	}
 	if strings.Count(path, ".") > 1 {
 		first, _, _ := strings.Cut(strings.Trim(path, "."), ".")
-		if strings.Contains(f.IncludeFields, first) {
+		if contains(f.IncludeFields, first) {
 			return false
 		}
 		if contains(entry.IncludeFields, first) {


### PR DESCRIPTION
This pull request adds support for message in a nested object.

```
$ echo '{"level": "INFO", "fields": {"message": "Hi"}}' | jl
   INFO: Hi
```

Fields in the nested object will be automatically included:
```
$ echo '{"level": "INFO", "fields": {"message": "Hi", "user": 611}}' | jl
   INFO: Hi [fields.user=611]
```

Closes #26 